### PR TITLE
Only append '?' if the query is non-empty

### DIFF
--- a/combineLoaders.js
+++ b/combineLoaders.js
@@ -2,7 +2,11 @@ var qs = require('qs');
 
 function combineLoaders(loaders) {
   return loaders.map(function(loaderEntry) {
-    return loaderEntry.loader + '?' + qs.stringify(loaderEntry.query, { arrayFormat: 'brackets' });
+    var query = qs.stringify(loaderEntry.query, { arrayFormat: 'brackets' });
+    if (query) {
+      query = '?' + query;
+    }
+    return loaderEntry.loader + query;
   }).join('!');
 }
 


### PR DESCRIPTION
If you pass `{}` or `null` as query config, some loaders can't handle the hanging `'?'`

e.g.

```
WARNING in ../nwb/~/css-loader?minimize=false!../nwb/~/autoprefixer-loader?!./src/Hello.css
Autoprefixer-loader got this undocumented option:
```