### PR TITLE
Disable encoding loader string due to error in Babel 6

### DIFF
--- a/combineLoaders.js
+++ b/combineLoaders.js
@@ -2,7 +2,7 @@ var qs = require('qs');
 
 function combineLoaders(loaders) {
   return loaders.map(function(loaderEntry) {
-    var query = qs.stringify(loaderEntry.query, { arrayFormat: 'brackets' });
+    var query = qs.stringify(loaderEntry.query, { arrayFormat: 'brackets', encode: false });
     if (query) {
       query = '?' + query;
     }


### PR DESCRIPTION
ERROR in ./src/main.js
Module build failed: ReferenceError: [BABEL] /Volumes/External/pierre/src/main.js: Unknown option: base.presets%5B%5D. Check out http://babeljs.io/docs/usage/options/ for more info